### PR TITLE
fix new line character

### DIFF
--- a/ios/Classes/Annotations/AnnotationController.swift
+++ b/ios/Classes/Annotations/AnnotationController.swift
@@ -117,7 +117,7 @@ class AnnotationController: NSObject {
         let y = self.getInfoWindowYOffset(annotationView: annotationView, annotation: annotation)
         annotationView.calloutOffset = CGPoint(x: x, y: y)
         if #available(iOS 9.0, *) {
-            let lines = annotation.subtitle?.split(whereSeparator: \.isNewline)
+            let lines = annotation.subtitle?.split(whereSeparator: { $0.isNewline })
             if lines != nil {
                 let customCallout = UIStackView()
                 customCallout.axis = .vertical


### PR DESCRIPTION
ran into this bug when trying to build my app (swift 5) 

 `/apple_maps_flutter-0.1.3/ios/Classes/Annotations/AnnotationController.swift:121:68: error: extra argument 'whereSeparator' in call
                let lines = annotation.subtitle?.split(whereSeparator: \.isNewline)
                                                                       ^~~~~~~~~~~
`
quick fix based off one of the answers on this thread: https://stackoverflow.com/questions/44450151/finding-new-line-character-in-a-string-in-swift-3