### PR TITLE
Adds support for my location with always authorization status

### DIFF
--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -196,14 +196,25 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
     }
     
     public func setUserLocation() {
-        if CLLocationManager.authorizationStatus() == .notDetermined {
+        let authorizationStatus = CLLocationManager.authorizationStatus()
+        
+        switch authorizationStatus {
+        case .notDetermined:
             locationManager.requestWhenInUseAuthorization()
-        } else if CLLocationManager.authorizationStatus() ==  .authorizedWhenInUse {
+            break
+            
+        case .authorizedAlways:
+            fallthrough
+        case .authorizedWhenInUse:
             locationManager.requestWhenInUseAuthorization()
             locationManager.desiredAccuracy = kCLLocationAccuracyBest
             locationManager.distanceFilter = kCLDistanceFilterNone
             locationManager.startUpdatingLocation()
             self.showsUserLocation = true
+            break
+            
+        default:
+            print("\(authorizationStatus.rawValue) is not supported.")
         }
     }
     


### PR DESCRIPTION
Currently, `apple_maps_flutter` will only show the user's location (i.e., a blue dot on the map) when the authorization status is `authorizedWhenInUse`.

https://github.com/LuisThein/apple_maps_flutter/blob/f787ab1bd3bc65cac023e4df5c14e4963fd37298/ios/Classes/MapView/FlutterMapView.swift#L198-L208

This PR enables the user's location when the authorization status transitions from `authorizedWhenInUse` to `authorizedAlways`. Closes LuisThein/platform_maps_flutter#28.