### PR TITLE
Implement getVisibleRegion() with MKMapView.region

### DIFF
--- a/ios/Classes/MapView/MapViewExtension.swift
+++ b/ios/Classes/MapView/MapViewExtension.swift
@@ -228,32 +228,18 @@ public extension MKMapView {
     
     func getVisibleRegion() -> Dictionary<String, Array<Double>> {
         if self.bounds.size != CGSize.zero {
-            // convert center coordiate to pixel space
-            let centerPixelX = self.longitudeToPixelSpaceX(longitude: self.centerCoordinate.longitude)
-            let centerPixelY = self.latitudeToPixelSpaceY(latitude: self.centerCoordinate.latitude)
-
-            // determine the scale value from the zoom level
-            let zoomExponent = Double(21 - Holder._zoomLevel)
-            let zoomScale = pow(2.0, zoomExponent)
-
-            // scale the map’s size in pixel space
-            let mapSizeInPixels = self.bounds.size
-            let scaledMapWidth = Double(mapSizeInPixels.width) * zoomScale
-            let scaledMapHeight = Double(mapSizeInPixels.height) * zoomScale;
-
-            // figure out the position of the top-left pixel
-            let topLeftPixelX = centerPixelX - (scaledMapWidth / 2);
-            let topLeftPixelY = centerPixelY - (scaledMapHeight / 2);
+            let center = self.region.center
+            let span = self.region.span
 
             // find the southwest coordinate
-            let minLng = self.pixelSpaceXToLongitude(pixelX: topLeftPixelX)
-            let minLat = self.pixelSpaceYToLatitude(pixelY: topLeftPixelY)
+            let minLng = center.longitude - span.longitudeDelta/2
+            let minLat = center.latitude - span.latitudeDelta/2
 
             // find the northeast coordinate
-            let maxLng = self.pixelSpaceXToLongitude(pixelX: topLeftPixelX + scaledMapWidth)
-            let maxLat = self.pixelSpaceYToLatitude(pixelY: topLeftPixelY + scaledMapHeight)
+            let maxLng = center.longitude + span.longitudeDelta/2
+            let maxLat = center.latitude + span.latitudeDelta/2
 
-            return ["northeast": [minLat, maxLng], "southwest": [maxLat, minLng]]
+            return ["northeast": [maxLat, maxLng], "southwest": [minLat, minLng]]
         }
         return ["northeast": [0.0, 0.0], "southwest": [0.0, 0.0]]
     }


### PR DESCRIPTION
This implementation respects the `padding` value and insets the region based on that padding. This allows setting the bounds and reading the bounds to have the same semantics with respect to the `padding`.

## Pre-launch Checklist

- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [ ] All existing and new tests are passing.