### PR TITLE
fix: Updated mapController.moveCamera to not animate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.0.3
+
+* Fixes an issue where mapController.moveCamera would animate the camera transition.
+* To animate a camera movement, mapController.animateCamera should be used instead.
+
 ## 1.0.2
 
 * Removed Android folder to fix build failures

--- a/ios/Classes/MapView/AppleMapController.swift
+++ b/ios/Classes/MapView/AppleMapController.swift
@@ -229,10 +229,10 @@ public class AppleMapController: NSObject, FlutterPlatformView {
         let positionData :Dictionary<String, Any> = self.toPositionData(data: args["cameraUpdate"] as! Array<Any>, animated: true)
         if !positionData.isEmpty {
             guard let _ = positionData["moveToBounds"] else {
-                self.mapView.setCenterCoordinate(positionData, animated: true)
+                self.mapView.setCenterCoordinate(positionData, animated: false)
                 return
             }
-            self.mapView.setBounds(positionData, animated: true)
+            self.mapView.setBounds(positionData, animated: false)
         }
     }
     

--- a/lib/src/controller.dart
+++ b/lib/src/controller.dart
@@ -194,7 +194,7 @@ class AppleMapController {
         <String, String>{'annotationId': annotationId.value});
   }
 
-  /// Changes the map camera position.
+  /// Changes the map camera position without animating the transition.
   ///
   /// The returned [Future] completes after the change has been made on the
   /// platform side.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.0.2
+version: 1.0.3
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues


### PR DESCRIPTION
To match the API of **google_maps_flutter**, updated `mapController.moveCamera` to move the camera without animating the transition.

To animate camera movement, `mapController.animateCamera` should be used instead.

Fixes LuisThein/apple_maps_flutter#31

---
From the GoogleMap API documentation:

[GoogleMap API - moveCamera](https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap#moveCamera(com.google.android.gms.maps.CameraUpdate))
`public final void moveCamera (CameraUpdate update)`

>Repositions the camera according to the instructions defined in the update. The move is instantaneous, and a subsequent getCameraPosition() will reflect the new position. See CameraUpdateFactory for a set of updates.

[GoogleMap API - animateCamera](https://developers.google.com/android/reference/com/google/android/gms/maps/GoogleMap#animateCamera(com.google.android.gms.maps.CameraUpdate))
`public final void animateCamera (CameraUpdate update)`

>Animates the movement of the camera from the current position to the position defined in the update. During the animation, a call to getCameraPosition() returns an intermediate location of the camera.
---

## Pre-launch Checklist

- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [x] All existing and new tests are passing.