### PR TITLE
fix: Odd movement of the Apple logo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 1.2.1
+
+* Fixed an issue where onCameraMove was not invoked by double-tapping
+* Added insetsLayoutMarginsFromSafeArea
+
 ## 1.2.0
 
 * Added a `markerAnnotationWithHue()` and `pinAnnotationWithHue()` method to allow custom marker/pin colors

--- a/example/lib/scrolling_map.dart
+++ b/example/lib/scrolling_map.dart
@@ -29,6 +29,7 @@ class ScrollingMapBody extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return SafeArea(
+      bottom: false,
       child: ListView(
         children: <Widget>[
           Card(
@@ -99,6 +100,7 @@ class ScrollingMapBody extends StatelessWidget {
                             () => ScaleGestureRecognizer(),
                           ),
                         ].toSet(),
+                        insetsLayoutMarginsFromSafeArea: false,
                       ),
                     ),
                   ),

--- a/ios/Classes/MapView/AppleMapController.swift
+++ b/ios/Classes/MapView/AppleMapController.swift
@@ -9,6 +9,7 @@ import Foundation
 import MapKit
 
 public class AppleMapController: NSObject, FlutterPlatformView {
+    var contentView: UIView
     var mapView: FlutterMapView
     var registrar: FlutterPluginRegistrar
     var channel: FlutterMethodChannel
@@ -24,6 +25,11 @@ public class AppleMapController: NSObject, FlutterPlatformView {
         
         self.mapView = FlutterMapView(channel: channel, options: options)
         self.registrar = registrar
+        
+        // To stop the odd movement of the Apple logo.
+        self.contentView = UIScrollView()
+        self.contentView.addSubview(mapView)
+        mapView.autoresizingMask = [.flexibleHeight, .flexibleWidth]
         
         self.initialCameraPosition = args["initialCameraPosition"]! as! Dictionary<String, Any>
         
@@ -56,7 +62,7 @@ public class AppleMapController: NSObject, FlutterPlatformView {
     }
     
     public func view() -> UIView {
-        return mapView
+        return contentView
     }
     
     private func setMethodCallHandlers() {

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -194,6 +194,13 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
                 self.maxZoomLevel = _maxZoom
             }
         }
+        
+        if let insetsSafeArea: Bool = options["insetsLayoutMarginsFromSafeArea"] as? Bool {
+            if #available(iOS 11.0, *) {
+                self.insetsLayoutMarginsFromSafeArea = insetsSafeArea
+            }
+        }
+
     }
     
     func setUserLocation() {

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -42,6 +42,7 @@ class AppleMap extends StatefulWidget {
     this.onTap,
     this.onLongPress,
     this.snapshotOptions,
+    this.insetsLayoutMarginsFromSafeArea = true,
   }) : super(key: key);
 
   final MapCreatedCallback? onMapCreated;
@@ -164,6 +165,10 @@ class AppleMap extends StatefulWidget {
   final EdgeInsets padding;
 
   final SnapshotOptions? snapshotOptions;
+
+  /// A Boolean value indicating whether the view's layout margins are updated
+  /// automatically to reflect the safe area.
+  final bool insetsLayoutMarginsFromSafeArea;
 
   @override
   State createState() => _AppleMapState();
@@ -336,6 +341,7 @@ class _AppleMapOptions {
     this.myLocationEnabled,
     this.myLocationButtonEnabled,
     this.padding,
+    this.insetsLayoutMarginsFromSafeArea,
   });
 
   static _AppleMapOptions fromWidget(AppleMap map) {
@@ -352,6 +358,7 @@ class _AppleMapOptions {
       myLocationEnabled: map.myLocationEnabled,
       myLocationButtonEnabled: map.myLocationButtonEnabled,
       padding: map.padding,
+      insetsLayoutMarginsFromSafeArea: map.insetsLayoutMarginsFromSafeArea,
     );
   }
 
@@ -379,6 +386,8 @@ class _AppleMapOptions {
 
   final EdgeInsets? padding;
 
+  final bool? insetsLayoutMarginsFromSafeArea;
+
   Map<String, dynamic> toMap() {
     final Map<String, dynamic> optionsMap = <String, dynamic>{};
 
@@ -400,6 +409,8 @@ class _AppleMapOptions {
     addIfNonNull('myLocationEnabled', myLocationEnabled);
     addIfNonNull('myLocationButtonEnabled', myLocationButtonEnabled);
     addIfNonNull('padding', _serializePadding(padding));
+    addIfNonNull(
+        'insetsLayoutMarginsFromSafeArea', insetsLayoutMarginsFromSafeArea);
     return optionsMap;
   }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.2.0
+version: 1.2.1
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues


### PR DESCRIPTION
Added insetsLayoutMarginsFromSafeArea parameter to control automatic update of layout margins.
When placing a MapView inside a ScrollView such as a ListView, set this flag to false to prevent the Apple logo from moving.

Fixes https://github.com/LuisThein/apple_maps_flutter/issues/40

## Pre-launch Checklist

- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [x] All existing and new tests are passing.