### PR TITLE
feat: add colorScheme parameter

### DIFF
--- a/example/lib/map_ui.dart
+++ b/example/lib/map_ui.dart
@@ -43,6 +43,7 @@ class MapUiBodyState extends State<MapUiBody> {
   bool _myLocationButtonEnabled = true;
   MinMaxZoomPreference _minMaxZoomPreference = MinMaxZoomPreference.unbounded;
   MapType _mapType = MapType.standard;
+  MapColorScheme _colorScheme = MapColorScheme.system;
   bool _rotateGesturesEnabled = true;
   bool _scrollGesturesEnabled = true;
   bool _pitchGesturesEnabled = true;
@@ -96,6 +97,18 @@ class MapUiBodyState extends State<MapUiBody> {
         });
       },
     );
+  }
+
+  Widget _colorSchemeCycler() {
+    final MapColorScheme nextScheme = MapColorScheme
+        .values[(_colorScheme.index + 1) % MapColorScheme.values.length];
+    return TextButton(
+        child: Text('change color scheme to $nextScheme'),
+        onPressed: () {
+          setState(() {
+            _colorScheme = nextScheme;
+          });
+        });
   }
 
   Widget _rotateToggler() {
@@ -170,6 +183,7 @@ class MapUiBodyState extends State<MapUiBody> {
   Widget build(BuildContext context) {
     final AppleMap appleMap = AppleMap(
       onMapCreated: onMapCreated,
+      colorScheme: _colorScheme,
       trackingMode: _trackingMode,
       initialCameraPosition: _kInitialPosition,
       compassEnabled: _compassEnabled,
@@ -207,6 +221,7 @@ class MapUiBodyState extends State<MapUiBody> {
                 children: <Widget>[
                   _compassToggler(),
                   _mapTypeCycler(),
+                  _colorSchemeCycler(),
                   _zoomBoundsToggler(),
                   _rotateToggler(),
                   _scrollToggler(),

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -20,7 +20,6 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
     var oldBounds: CGRect?
     var options: Dictionary<String, Any>?
     var isMyLocationButtonShowing: Bool? = false
-    var mapStyle: Int? = 0
     
     fileprivate let locationManager: CLLocationManager = CLLocationManager()
     

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -20,6 +20,7 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
     var oldBounds: CGRect?
     var options: Dictionary<String, Any>?
     var isMyLocationButtonShowing: Bool? = false
+    var mapStyle: Int? = 0
     
     fileprivate let locationManager: CLLocationManager = CLLocationManager()
     
@@ -143,6 +144,14 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
         
         if let mapType: Int = options["mapType"] as? Int {
             self.mapType = self.mapTypes[mapType]
+        }
+
+        if let mapStyle: Int = options["mapStyle"] as? Int {
+            if #available(iOS 13.0, *) {
+                if mapStyle != 0 {
+                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mapStyle) ?? .unspecified
+                }
+            }
         }
         
         if let trafficEnabled: Bool = options["trafficEnabled"] as? Bool {

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -145,10 +145,10 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
             self.mapType = self.mapTypes[mapType]
         }
 
-        if let mapStyle: Int = options["mapStyle"] as? Int {
+        if let colorScheme: Int = options["colorScheme"] as? Int {
             if #available(iOS 13.0, *) {
-                if mapStyle != 0 {
-                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: mapStyle) ?? .unspecified
+                if colorScheme != 0 {
+                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: colorScheme) ?? .unspecified
                 }
             }
         }

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -147,9 +147,7 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
 
         if let colorScheme: Int = options["colorScheme"] as? Int {
             if #available(iOS 13.0, *) {
-                if colorScheme != 0 {
-                    self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: colorScheme) ?? .unspecified
-                }
+                self.overrideUserInterfaceStyle = UIUserInterfaceStyle(rawValue: colorScheme) ?? .unspecified
             }
         }
         

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -23,7 +23,7 @@ class AppleMap extends StatefulWidget {
     this.compassEnabled = true,
     this.trafficEnabled = false,
     this.mapType = MapType.standard,
-    this.mapStyle = MapStyle.system,
+    this.colorScheme = MapColorScheme.system,
     this.minMaxZoomPreference = MinMaxZoomPreference.unbounded,
     this.trackingMode = TrackingMode.none,
     this.rotateGesturesEnabled = true,
@@ -59,8 +59,8 @@ class AppleMap extends StatefulWidget {
   /// Type of map tiles to be rendered.
   final MapType mapType;
 
-  /// TODO
-  final MapStyle mapStyle;
+  /// Color scheme for the standard map to use.
+  final MapColorScheme colorScheme;
 
   /// The mode used to track the user location.
   final TrackingMode trackingMode;
@@ -331,7 +331,7 @@ class _AppleMapOptions {
     this.compassEnabled,
     this.trafficEnabled,
     this.mapType,
-    this.mapStyle,
+    this.colorScheme,
     this.minMaxZoomPreference,
     this.rotateGesturesEnabled,
     this.scrollGesturesEnabled,
@@ -348,7 +348,7 @@ class _AppleMapOptions {
       compassEnabled: map.compassEnabled,
       trafficEnabled: map.trafficEnabled,
       mapType: map.mapType,
-      mapStyle: map.mapStyle,
+      colorScheme: map.colorScheme,
       minMaxZoomPreference: map.minMaxZoomPreference,
       rotateGesturesEnabled: map.rotateGesturesEnabled,
       scrollGesturesEnabled: map.scrollGesturesEnabled,
@@ -367,7 +367,7 @@ class _AppleMapOptions {
 
   final MapType? mapType;
 
-  final MapStyle? mapStyle;
+  final MapColorScheme? colorScheme;
 
   final MinMaxZoomPreference? minMaxZoomPreference;
 
@@ -399,7 +399,7 @@ class _AppleMapOptions {
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
-    addIfNonNull('mapStyle', mapStyle?.index);
+    addIfNonNull('colorScheme', colorScheme?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -23,6 +23,7 @@ class AppleMap extends StatefulWidget {
     this.compassEnabled = true,
     this.trafficEnabled = false,
     this.mapType = MapType.standard,
+    this.mapStyle = MapStyle.system,
     this.minMaxZoomPreference = MinMaxZoomPreference.unbounded,
     this.trackingMode = TrackingMode.none,
     this.rotateGesturesEnabled = true,
@@ -57,6 +58,9 @@ class AppleMap extends StatefulWidget {
 
   /// Type of map tiles to be rendered.
   final MapType mapType;
+
+  /// TODO
+  final MapStyle mapStyle;
 
   /// The mode used to track the user location.
   final TrackingMode trackingMode;
@@ -327,6 +331,7 @@ class _AppleMapOptions {
     this.compassEnabled,
     this.trafficEnabled,
     this.mapType,
+    this.mapStyle,
     this.minMaxZoomPreference,
     this.rotateGesturesEnabled,
     this.scrollGesturesEnabled,
@@ -343,6 +348,7 @@ class _AppleMapOptions {
       compassEnabled: map.compassEnabled,
       trafficEnabled: map.trafficEnabled,
       mapType: map.mapType,
+      mapStyle: map.mapStyle,
       minMaxZoomPreference: map.minMaxZoomPreference,
       rotateGesturesEnabled: map.rotateGesturesEnabled,
       scrollGesturesEnabled: map.scrollGesturesEnabled,
@@ -360,6 +366,8 @@ class _AppleMapOptions {
   final bool? trafficEnabled;
 
   final MapType? mapType;
+
+  final MapStyle? mapStyle;
 
   final MinMaxZoomPreference? minMaxZoomPreference;
 
@@ -391,6 +399,7 @@ class _AppleMapOptions {
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
+    addIfNonNull('mapStyle', mapStyle?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -187,7 +187,7 @@ class _AppleMapState extends State<AppleMap> {
   Widget build(BuildContext context) {
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition._toMap(),
-      'options': _appleMapOptions.toMap(context: context),
+      'options': _appleMapOptions.toMap(),
       'annotationsToAdd': _serializeAnnotationSet(widget.annotations),
       'polylinesToAdd': _serializePolylineSet(widget.polylines),
       'polygonsToAdd': _serializePolygonSet(widget.polygons),
@@ -387,7 +387,7 @@ class _AppleMapOptions {
 
   final EdgeInsets? padding;
 
-  Map<String, dynamic> toMap({BuildContext? context}) {
+  Map<String, dynamic> toMap() {
     final Map<String, dynamic> optionsMap = <String, dynamic>{};
 
     void addIfNonNull(String fieldName, dynamic value) {
@@ -396,22 +396,10 @@ class _AppleMapOptions {
       }
     }
 
-    if (context != null) {
-      final systemScheme = Theme.of(context).brightness == Brightness.dark
-          ? MapColorScheme.dark
-          : MapColorScheme.light;
-      addIfNonNull(
-          'colorScheme',
-          colorScheme == MapColorScheme.system
-              ? systemScheme.index
-              : colorScheme?.index);
-    } else {
-      addIfNonNull('colorScheme', colorScheme?.index);
-    }
-
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
+    addIfNonNull('colorScheme', colorScheme?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -187,7 +187,7 @@ class _AppleMapState extends State<AppleMap> {
   Widget build(BuildContext context) {
     final Map<String, dynamic> creationParams = <String, dynamic>{
       'initialCameraPosition': widget.initialCameraPosition._toMap(),
-      'options': _appleMapOptions.toMap(),
+      'options': _appleMapOptions.toMap(context: context),
       'annotationsToAdd': _serializeAnnotationSet(widget.annotations),
       'polylinesToAdd': _serializePolylineSet(widget.polylines),
       'polygonsToAdd': _serializePolygonSet(widget.polygons),
@@ -387,7 +387,7 @@ class _AppleMapOptions {
 
   final EdgeInsets? padding;
 
-  Map<String, dynamic> toMap() {
+  Map<String, dynamic> toMap({BuildContext? context}) {
     final Map<String, dynamic> optionsMap = <String, dynamic>{};
 
     void addIfNonNull(String fieldName, dynamic value) {
@@ -396,10 +396,22 @@ class _AppleMapOptions {
       }
     }
 
+    if (context != null) {
+      final systemScheme = Theme.of(context).brightness == Brightness.dark
+          ? MapColorScheme.dark
+          : MapColorScheme.light;
+      addIfNonNull(
+          'colorScheme',
+          colorScheme == MapColorScheme.system
+              ? systemScheme.index
+              : colorScheme?.index);
+    } else {
+      addIfNonNull('colorScheme', colorScheme?.index);
+    }
+
     addIfNonNull('compassEnabled', compassEnabled);
     addIfNonNull('trafficEnabled', trafficEnabled);
     addIfNonNull('mapType', mapType?.index);
-    addIfNonNull('colorScheme', colorScheme?.index);
     addIfNonNull('minMaxZoomPreference', minMaxZoomPreference?._toJson());
     addIfNonNull('rotateGesturesEnabled', rotateGesturesEnabled);
     addIfNonNull('scrollGesturesEnabled', scrollGesturesEnabled);

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -16,7 +16,7 @@ enum MapType {
   hybrid,
 }
 
-enum MapStyle {
+enum MapColorScheme {
   /// Follow system style
   system,
   

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -16,6 +16,14 @@ enum MapType {
   hybrid,
 }
 
+enum MapStyle {
+  /// Follow system style
+  system,
+  
+  light, 
+  dark,
+}
+
 enum TrackingMode {
   // the user's location is not followed
   none,


### PR DESCRIPTION
This PR allows the developers to programmatically change the color scheme of the map, the current behavior is that the map always follows the system (not Flutter's theme Brightness) appearance settings. There is still a bug regarding using the app's Brightness but I figured it can be worked on later, as that is the exact behavior atm.

This could be classified as a fix to #29, although that issue might involve more stuff than just the scheme.

## Pre-launch Checklist

- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [x] All existing and new tests are passing.