### PR TITLE
Complete Map Types list

### DIFF
--- a/example/test_driver/test_widgets.dart
+++ b/example/test_driver/test_widgets.dart
@@ -8,5 +8,5 @@ import 'package:flutter/widgets.dart';
 
 Future<void> pumpWidget(Widget widget) {
   runApp(widget);
-  return WidgetsBinding.instance!.endOfFrame;
+  return WidgetsBinding.instance.endOfFrame;
 }

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -27,6 +27,9 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
         MKMapType.standard,
         MKMapType.satellite,
         MKMapType.hybrid,
+        MKMapType.satelliteFlyover,
+        MKMapType.hybridFlyover,
+        MKMapType.mutedStandard,
     ]
     
     let userTrackingModes: Array<MKUserTrackingMode> = [

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -400,7 +400,6 @@ class _AppleMapOptions {
     addIfNonNull('myLocationEnabled', myLocationEnabled);
     addIfNonNull('myLocationButtonEnabled', myLocationButtonEnabled);
     addIfNonNull('padding', _serializePadding(padding));
-    print('optionsMap: $optionsMap');
     return optionsMap;
   }
 

--- a/lib/src/apple_map.dart
+++ b/lib/src/apple_map.dart
@@ -400,6 +400,7 @@ class _AppleMapOptions {
     addIfNonNull('myLocationEnabled', myLocationEnabled);
     addIfNonNull('myLocationButtonEnabled', myLocationButtonEnabled);
     addIfNonNull('padding', _serializePadding(padding));
+    print('optionsMap: $optionsMap');
     return optionsMap;
   }
 

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -15,10 +15,13 @@ enum MapType {
   /// Hybrid tiles (satellite images with some labels/overlays)
   hybrid,
 
+  // A satellite image of the area with flyover data where available.
   satelliteFlyover,
 
+  // A hybrid satellite image with flyover data where available.
   hybridFlyover,
 
+  // A street map where MapKit emphasizes your data over the underlying map details.
   mutedStandard,
 }
 

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -14,6 +14,12 @@ enum MapType {
 
   /// Hybrid tiles (satellite images with some labels/overlays)
   hybrid,
+
+  satelliteFlyover,
+
+  hybridFlyover,
+
+  mutedStandard,
 }
 
 enum TrackingMode {


### PR DESCRIPTION
Add missing map types: SatelliteFlyover, Hybrid Flyover and Muted Standard

## Pre-launch Checklist

- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [ ] All existing and new tests are passing.