### PR TITLE
Animate annotation updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.0
+
+* Animate marker position changes instead of removing and re-adding
 ## 1.2.0
 
 * Added a `markerAnnotationWithHue()` and `pinAnnotationWithHue()` method to allow custom marker/pin colors

--- a/ios/Classes/Annotations/AnnotationController.swift
+++ b/ios/Classes/Annotations/AnnotationController.swift
@@ -94,7 +94,7 @@ extension AppleMapController: AnnotationDelegate {
                 let newAnnotation = FlutterAnnotation.init(fromDictionary: annotationData, registrar: registrar)
                 if annotationToChange != newAnnotation {
                     if !annotationToChange.wasDragged {
-                        addAnnotation(annotation: newAnnotation)
+                        updateAnnotation(annotation: newAnnotation)
                     } else {
                         annotationToChange.wasDragged = false
                     }
@@ -202,6 +202,16 @@ extension AppleMapController: AnnotationDelegate {
             channel.invokeMethod("annotation#onZIndexChanged", arguments: ["annotationId": annotation.id!, "zIndex": annotation.zIndex])
         }
         self.mapView.addAnnotation(annotation)
+    }
+
+    private func updateAnnotation(annotation: FlutterAnnotation) {
+        if self.annotationExists(with: annotation.id) {
+            UIView.animate(withDuration: 0.32, animations: {
+                let oldAnnotation = self.getAnnotation(with: annotation.id)
+                oldAnnotation?.coordinate = annotation.coordinate
+                oldAnnotation?.title = annotation.title
+            })
+        }
     }
 
     private func getNextAnnotationZIndex() -> Double {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.2.0
+version: 1.3.0
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues


### PR DESCRIPTION
Instead of removing and re-adding annotations which causes the annotation to flash, changing annotations now animate to their new location.

Example of the old behaviour when moving a marker:

https://github.com/LuisThein/apple_maps_flutter/assets/9100419/f956ae33-7302-4268-8c5c-b65c5abd2334

Example of new behaviour with animated marker moving (which also stays selected):

https://github.com/LuisThein/apple_maps_flutter/assets/9100419/aba0d941-d7b1-4a6a-983f-656ea4aeffe4


## Pre-launch Checklist

- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [ ] All existing and new tests are passing.