### PR TITLE
fix: Fatal error: Attempted to read an unowned reference but the obje…

### DIFF
--- a/ios/Classes/MapView/AppleMapController.swift
+++ b/ios/Classes/MapView/AppleMapController.swift
@@ -322,15 +322,22 @@ extension AppleMapController {
         snapShot?.cancel()
         
         if #available(iOS 10.0, *) {
-            snapShot?.start { [unowned self] snapshot, error in
+            snapShot?.start { [weak self] snapshot, error in
+                guard let self = self else {
+                    return
+                }
+                
                 guard let snapshot = snapshot, error == nil else {
                     onCompletion(nil, error)
                     return
                 }
-
-                let image = UIGraphicsImageRenderer(size: self.snapShotOptions.size).image { context in
+                
+                let image = UIGraphicsImageRenderer(size: self.snapShotOptions.size).image { [weak self] context in
+                    guard let self = self else {
+                        return
+                    }
                     snapshot.image.draw(at: .zero)
-                    let rect = snapShotOptions.mapRect
+                    let rect = self.snapShotOptions.mapRect
                     if options.showAnnotations {
                         for annotation in self.mapView.getMapViewAnnotations() {
                             self.drawAnnotations(annotation: annotation, point: snapshot.point(for: annotation!.coordinate))


### PR DESCRIPTION
## Step
When a user recalls a return operation in an iOS application, taking screenshots at the same time may cause the application to crash

## Error
Fatal error: Attempted to read an unowned reference but the object was already deallocated
<img width="1215" alt="image" src="https://github.com/LuisThein/apple_maps_flutter/assets/8444646/0eb0f161-a43b-4c55-b0c7-e0dd228381e5">

## Pre-launch Checklist

- [ ] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [ ] I updated CHANGELOG.md to add a description of the change.
- [ ] I updated/added relevant documentation (doc comments with `///`).
- [ ] I added new tests to check the change I am making if a test is possible.
- [ ] All existing and new tests are passing.