### PR TITLE
Add missing map types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.4.0
+
+*  Added three new map types: `MapType.satelliteFlyover`, `MapType.hybridFlyover`, and `MapType.mutedStandard`
+
 ## 1.3.0
 
 * Animate marker position changes instead of removing and re-adding

--- a/ios/Classes/MapView/FlutterMapView.swift
+++ b/ios/Classes/MapView/FlutterMapView.swift
@@ -27,6 +27,9 @@ class FlutterMapView: MKMapView, UIGestureRecognizerDelegate {
         MKMapType.standard,
         MKMapType.satellite,
         MKMapType.hybrid,
+        MKMapType.satelliteFlyover,
+        MKMapType.hybridFlyover,
+        MKMapType.mutedStandard,
     ]
     
     let userTrackingModes: Array<MKUserTrackingMode> = [

--- a/lib/src/ui.dart
+++ b/lib/src/ui.dart
@@ -14,6 +14,15 @@ enum MapType {
 
   /// Hybrid tiles (satellite images with some labels/overlays)
   hybrid,
+
+  /// Satellite flyover tiles (aerial photos)
+  satelliteFlyover,
+
+  /// Hybrid flyover tiles (satellite images with some labels/overlays)
+  hybridFlyover,
+
+  /// Muted standard tiles (traffic and labels, subtle terrain information)
+  mutedStandard,
 }
 
 enum TrackingMode {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apple_maps_flutter
 description: This plugin uses the Flutter platform view to display an Apple Maps widget.
-version: 1.3.0
+version: 1.4.0
 homepage: https://luisthein.de
 repository: https://github.com/LuisThein/apple_maps_flutter
 issue_tracker: https://github.com/LuisThein/apple_maps_flutter/issues


### PR DESCRIPTION
Added missing map types to the `MapType` enum.

## Pre-launch Checklist

- [x] I updated pubspec.yaml with an appropriate new version according to the [pub versioning philosophy].
- [x] I updated CHANGELOG.md to add a description of the change.
- [x] I updated/added relevant documentation (doc comments with `///`).
- [x] I added new tests to check the change I am making if a test is possible.
- [x] All existing and new tests are passing.